### PR TITLE
fork control: the first arg is not iterator, but generator function: update docs and arg name

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ const subGenerator = function*(timeout, input) {
 }
 
 runtime(function*() {
-  yield fork(subgenerator(10, 1))
-  yield fork(subgenerator(5, 2))
+  yield fork(subgenerator, 10, 1)
+  yield fork(subgenerator, 5, 2)
 })
 
 // this will output 2 than 1
@@ -202,8 +202,8 @@ const subGenerator = function*(timeout, input) {
 }
 
 runtime(function*() {
-  const task1 = yield fork(subgenerator(10, 1))
-  const task2 = yield fork(subgenerator(5, 2))
+  const task1 = yield fork(subgenerator, 10, 1)
+  const task2 = yield fork(subgenerator, 5, 2)
 
   yield delay(6)
   const output = yield join(task1)

--- a/src/controls/async.js
+++ b/src/controls/async.js
@@ -15,7 +15,7 @@ export const fork = (value, next, rungen) => {
   const dispatcher = createDispatcher()
   forkedTasks.set(task, dispatcher)
   rungen(
-    value.iterator.apply(null, value.args),
+    value.generator.apply(null, value.args),
     result => dispatcher.dispatch(result),
     err => dispatcher.dispatch(error(err))
   )

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -10,9 +10,9 @@ export const error = err => ({
   error: err
 })
 
-export const fork = (iterator, ...args) => ({
+export const fork = (generator, ...args) => ({
   type: keys.fork,
-  iterator,
+  generator,
   args
 })
 


### PR DESCRIPTION
The README contains an example where the `fork` control gets an iterator (created by calling a generator function) as the first arg. That's not what the control expects though: the arg is supposed to be a generator function that returns an iterator only after it's called.

This PR updates the README, and also renames the internal field from the misleading `iterator` to the correct name: `generator`.